### PR TITLE
Photos section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ tmp/
 config/database.yml
 .DS_Store
 public/system/**/*
+*.swp
 public/assets
 spec/fixtures/vcr_cassettes/*

--- a/app/assets/stylesheets/photos.css.scss
+++ b/app/assets/stylesheets/photos.css.scss
@@ -1,0 +1,7 @@
+@import 'mixins';
+
+body.photos.index {
+  li.photos {
+    @include active
+  }
+}

--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -1,0 +1,7 @@
+class PhotosController < ApplicationController
+  def index
+    @photo_albums = Photo.all(:params => { :key => Rails.application.config.meetup_com_api_key, :page => 100, :group_id => '2270561' }).select{|p| p.albumtitle!="Meetup Group Photo Album"}
+    rescue ActiveResource::TimeoutError, ActiveResource::BadRequest => e
+      @photo_albums = []
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,6 @@
+class Image < ActiveRecord::Base
+  belongs_to :member
+
+  delegate :thumb, :to => :file
+  image_accessor :file
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -3,6 +3,6 @@ class Member < ActiveResource::Base
   self.timeout = 5
 
   def photo
-    Photo.where(:member_id => id).first || Photo.create(:member_id => id, :file_url => photo_url) unless photo_url.blank?
+    Image.where(:member_id => id).first || Image.create(:member_id => id, :file_url => photo_url) unless photo_url.blank?
   end
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,6 +1,4 @@
-class Photo < ActiveRecord::Base
-  belongs_to :member
-
-  delegate :thumb, :to => :file
-  image_accessor :file
+class Photo < ActiveResource::Base
+  self.site = "https://api.meetup.com"
+  self.timeout = 5
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
         <ul class="nav">
           <li class="home"><%= link_to t('.home.title'), locale_root_path %></li>
           <li class="members"><%= link_to t('.members.title'), members_path %></li>
+          <li class="photos"><%= link_to t('.photos.title'), photos_path %></li>
           <li class="events"><%= link_to t('.meetups.title'), events_path %></li>
           <li class="projects"><%= link_to t('.projects.title'), "#" %></li>
         </ul>

--- a/app/views/photos/index.html.erb
+++ b/app/views/photos/index.html.erb
@@ -1,0 +1,19 @@
+<div class="hero-unit">
+  <h1><%= t '.title' %></h1>
+
+  <% @photo_albums.each do |album| %>
+    <h2><%= album.albumtitle %></h2>
+    <ul class="media-grid">
+      <% album.thumb_urls.each_with_index do |thumb, i| %>
+        <li class="photo_photo">
+          <%= link_to image_tag(thumb, :alt => "", :class => "thumbnail", :'data-original-title' => "", :'data-content' => ""), album.photo_urls[i], :target => "_blank" if thumb %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <% if @photo_albums.blank? %>
+    <%= t '.api_error' %>
+  <% end %>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,12 +32,19 @@ en:
       roster: Group Members (%{number})
       api_error: Sorry, the meetup.com Members API is not available right now. Please check back a bit later.
 
+  photos:
+    index:
+      title: Photos
+      api_error: Sorry, the meetup.com Photos API is not available right now. Please check back a bit later.
+
   layouts:
     application:
       home:
         title: Home
       members:
         title: Members
+      photos:
+        title: Photos
       meetups:
         title: Meetups
       projects:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,12 +32,19 @@ ja:
       roster: 現在メンバー%{number}人
       api_error: 申し訳ありませんが、meetup.comメンバーAPIは現在利用できません。少し後で確認してください。
 
+  photos:
+    index:
+      title: 写真
+      api_error: 申し訳ありませんが、meetup.com写真APIは現在利用できません。少し後で確認してください。
+
   layouts:
     application:
       home:
         title: ホーム
       members:
         title: メンバー
+      photos:
+        title: 写真
       meetups:
         title: ミートアップ
       projects:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Tokyorails::Application.routes.draw do
   scope "(:locale)", :locale => /en|ja/ do
     resources :members
     resources :events
+    resources :photos
   end
 
   match '/:locale' => 'homepage#index', :as => :locale_root

--- a/db/migrate/20111202160339_create_images.rb
+++ b/db/migrate/20111202160339_create_images.rb
@@ -1,0 +1,11 @@
+class CreateImages < ActiveRecord::Migration
+  def change
+    create_table :images do |t|
+      t.string :member_id
+      t.string :file_uid
+
+      t.timestamps
+    end
+    add_index :images, :member_id
+  end
+end

--- a/db/migrate/20111203072945_drop_photos.rb
+++ b/db/migrate/20111203072945_drop_photos.rb
@@ -1,0 +1,15 @@
+class DropPhotos < ActiveRecord::Migration
+  def up
+    drop_table :photos
+  end
+
+  def down
+    create_table :photos do |t|
+      t.string :member_id
+      t.string :file_uid
+
+      t.timestamps
+    end
+    add_index :photos, :member_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20111106062005) do
+ActiveRecord::Schema.define(:version => 20111203072945) do
 
-  create_table "photos", :force => true do |t|
+  create_table "images", :force => true do |t|
     t.string   "member_id"
     t.string   "file_uid"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  add_index "photos", ["member_id"], :name => "index_photos_on_member_id"
+  add_index "images", ["member_id"], :name => "index_images_on_member_id"
 
 end

--- a/spec/factories/photo_factory.rb
+++ b/spec/factories/photo_factory.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :photo do
+  factory :image do
     member_id
     file File.new(Rails.root.join('spec','fixtures','example.jpg'))
   end

--- a/spec/models/photo_spec.rb
+++ b/spec/models/photo_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Photo do
+  context "given there are photos on meetup.com" do
+
+    WebMock.allow_net_connect!
+    describe ".all" do
+      it "returns a list of all photos" do
+        photo_albums = Photo.all(:params => { :key => Rails.application.config.meetup_com_api_key, :page => 100, :group_id => '2270561' })
+        photo_albums.size.should > 4
+      end
+    end
+  end
+end

--- a/spec/requests/members_index_spec.rb
+++ b/spec/requests/members_index_spec.rb
@@ -7,7 +7,7 @@ feature "Viewing users" do
   scenario "A list of registered users" do
     visit members_path
     page.should have_content('Group Members (')
-    page.should have_css("img", :src => "#{Photo.last.thumb('90x90#').url}")
+    page.should have_css("img", :src => "#{Image.last.thumb('90x90#').url}")
     page.should have_css("img", :alt => "Mr Member.")
   end
 

--- a/spec/requests/photos_index_spec.rb
+++ b/spec/requests/photos_index_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+feature "Viewing photos" do
+  API_PHOTOS_URL = "https://api.meetup.com/photos.json?key=#{Rails.application.config.meetup_com_api_key}&page=100&group_id=2270561"
+
+  use_vcr_cassette
+  scenario "A list of photos" do
+    visit photos_path
+    page.should have_content('Photos')
+    page.should have_css("img", :alt => "meetup photo")
+  end
+
+  scenario "Viewing photos page when the meetup.com api returns a timeout" do
+    stub_request(:get, API_PHOTOS_URL).to_timeout
+    visit photos_path
+    page.should have_content("Sorry, the meetup.com Photos API is not available right now. Please check back a bit later.")
+  end
+
+  scenario "Viewing photos page when the meetup.com api returns a 400 Bad request" do
+    stub_request(:get, API_PHOTOS_URL).to_return(:body => "Bad Request", :status => 400)
+    visit photos_path
+    page.should have_content("Sorry, the meetup.com Photos API is not available right now. Please check back a bit later.")
+  end
+end


### PR DESCRIPTION
Adds (event) photos section to the site.

Changed the member photo model name to Image so that Photo could be used to interface with the Meetup API.

Currently just gets all of the group's albums, excludes the default album containing the logo, and img src's directly to their thumb url's. Clicking a thumb just opens target=_blank to the non-thumb url.
