### PR TITLE
Change the Image member_id field from a string to an integer

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -4,9 +4,9 @@ class Member < ActiveRecord::Base
   validates_uniqueness_of :meetup_id
   validates_uniqueness_of :github_username, :allow_blank => true
 
-#  has_one :image
+  has_one :image
 
   def photo
-    Image.where(:member_id => meetup_id).first || Image.create(:member_id => meetup_id, :file_url => photo_url) unless photo_url.blank?
+    self.image || self.create_image(:file_url => photo_url) unless photo_url.blank?
   end
 end

--- a/db/migrate/20111202160339_create_images.rb
+++ b/db/migrate/20111202160339_create_images.rb
@@ -1,7 +1,7 @@
 class CreateImages < ActiveRecord::Migration
   def change
     create_table :images do |t|
-      t.string :member_id
+      t.integer :member_id
       t.string :file_uid
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,7 @@
 ActiveRecord::Schema.define(:version => 20111203121725) do
 
   create_table "images", :force => true do |t|
-    t.string   "member_id"
+    t.integer  "member_id"
     t.string   "file_uid"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/lib/tokyorails/meetup_tasks.rb
+++ b/lib/tokyorails/meetup_tasks.rb
@@ -17,7 +17,7 @@ module MeetupTasks
     meetup_member_list = get_members_list
     meetup_member_list.each do |meetup_member|
 
-      member = Member.where(:meetup_id => meetup_member['member_id'].to_s).first
+      member = Member.where(:meetup_id => meetup_member['member_id']).first
 
       if member.nil?
         update_member(Member.new, meetup_member)


### PR DESCRIPTION
Change the Image member_id field from a string to an integer to allow for has_one / belongs_to relationship to work. All model specs are now passing against Postgresql.

I did this the simple way (changing the original migration file). While this is not usually ideal in this case it saves us creating a data migration and there is no data in the database that we cannot afford to lose in this early stage of the site.

Will require a rake db:migrate:reset by developers and on the production site
