### PR TITLE
case insensitive query for member search with postgresql

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -10,7 +10,7 @@ class Member < ActiveRecord::Base
   has_one :image, :dependent => :destroy
 
   scope :authenticated, where("access_token IS NOT NULL AND access_token != ''")
-  scope :name_like, lambda {|query| where("name  LIKE ?", "%#{query}%")}
+  scope :name_like, lambda {|query| where("UPPER(name) LIKE UPPER(?)", "%#{query}%")}
 
   def self.authenticate(auth)
     member = Member.find_by_uid(auth['uid'].to_s)

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -9,9 +9,11 @@
 
   <ul class="thumbnails">
     <% @members.shuffle.each do |member| %>
-    <li class="member_photo">
-      <%= link_to image_tag(member.photo.thumb('90x90#').url, :alt => member.name), member, :class => "thumbnail", :'title' => member.name, :'data-content' => member.bio if member.photo %>
-    </li>
-  <% end %>
+      <% if member.photo %>
+        <li class="member_photo">
+          <%= link_to image_tag(member.photo.thumb('90x90#').url, :alt => member.name), member, :class => "thumbnail", :'title' => member.name, :'data-content' => member.bio %>
+        </li>
+      <% end %>
+    <% end %>
   </ul>
 </div>


### PR DESCRIPTION
Member search is case insensitive locally but sensitive in production, because `LIKE` is case insenstive in sqlite and sensitive in postgresql.

This commit uses UPPER on both sides of the `LIKE` comparison for case insensitivity even on postgresql.

Note, this is untested on postgresql, as I don't have it setup on my local environment.
