### PR TITLE
Add Photos to Events

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,8 @@
 class Event < ActiveRecord::Base
   include Tokyorails::GithubMethods
 
+  has_many :images, :as => :imageable, :dependent => :destroy
+
   scope :upcoming, where(:status => 'upcoming')
   scope :past, where(:status => 'past')
   scope :recent, order('time DESC')

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,6 +1,6 @@
 # -*- encoding : utf-8 -*-
 class Image < ActiveRecord::Base
-  belongs_to :member
+  belongs_to :imageable, :polymorphic => true
 
   delegate :thumb, :to => :file
   image_accessor :file

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -7,7 +7,7 @@ class Member < ActiveRecord::Base
   validates_uniqueness_of :uid
   validates_uniqueness_of :github_username, :allow_blank => true
 
-  has_one :image, :dependent => :destroy
+  has_one :image, :as => :imageable, :dependent => :destroy
 
   scope :authenticated, where("access_token IS NOT NULL AND access_token != ''")
   scope :name_like, lambda {|query| where("UPPER(name) LIKE UPPER(?)", "%#{query}%")}

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -32,6 +32,16 @@
   <% @past_events.recent.each do |event| %>
     <div class="row">
       <h2><%= link_to event.name, event.event_url %></h3>
+    <% unless event.images.empty? %>
+    <h3><%= t '.photos' %></h3>
+    <ul class="thumbnails">
+      <% event.images.each do |photo| %>
+        <li class="photo_photo">
+          <%= link_to image_tag(photo.thumb('90x90#').url, :alt => "", :'data-original-title' => "", :'data-content' => ""), photo.file.jpg.url, :class => "thumbnail", :target => "_blank" if photo %>
+        </li>
+      <% end %>
+    </ul>
+    <% end %>
       <h3><%= t '.attended', :number => event.yes_rsvp_count %></h3>
       <ul class="attending">
         <% Rsvp.where(:meetup_id => event.uid).attending.each do |rsvp| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
       no_upcoming_meetups: The next meetup is not yet scheduled, but please register to get notified.
       attending: "%{number} planning to attend so far..."
       attended: "%{number} attended"
+      photos: Photos
       join: RSVP for the Next Meetup
       register: Register to Get Notified
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -29,6 +29,7 @@ ja:
       no_upcoming_meetups: 次のミートアップはまだ未定ですが、通知を受け取るために是非登録してください。
       attending: "%{number} 人が参加表明しています"
       attended: "%{number} 人が参加しました"
+      photos:  写真
       join: 次のミートアップに参加申し込み
       register: 次のイベントに申込む
 

--- a/db/migrate/20120515094337_add_imageable_to_images.rb
+++ b/db/migrate/20120515094337_add_imageable_to_images.rb
@@ -1,0 +1,17 @@
+class AddImageableToImages < ActiveRecord::Migration
+  def self.up
+    change_table :images do |t|
+      t.references :imageable, :polymorphic => true
+      execute "UPDATE `images` SET imageable_id = member_id WHERE imageable_id IS NULL"
+      execute "UPDATE `images` SET imageable_type = 'Member' WHERE imageable_type IS NULL"
+      t.remove_index :member_id
+      t.remove :member_id
+    end
+  end
+  
+  def self.down
+    change_table :images do |t|
+      t.remove_references :imageable, :polymorphic => true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120504150757) do
+ActiveRecord::Schema.define(:version => 20120515094337) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -19,8 +19,8 @@ ActiveRecord::Schema.define(:version => 20120504150757) do
     t.integer  "author_id"
     t.string   "author_type"
     t.text     "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
     t.string   "namespace"
   end
 
@@ -39,8 +39,8 @@ ActiveRecord::Schema.define(:version => 20120504150757) do
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
     t.string   "last_sign_in_ip"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                             :null => false
+    t.datetime "updated_at",                             :null => false
   end
 
   add_index "admin_users", ["email"], :name => "index_admin_users_on_email", :unique => true
@@ -54,20 +54,19 @@ ActiveRecord::Schema.define(:version => 20120504150757) do
     t.text     "description"
     t.datetime "time"
     t.integer  "yes_rsvp_count"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",     :null => false
+    t.datetime "updated_at",     :null => false
   end
 
   add_index "events", ["uid"], :name => "index_events_on_uid"
 
   create_table "images", :force => true do |t|
-    t.integer  "member_id"
     t.string   "file_uid"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",     :null => false
+    t.datetime "updated_at",     :null => false
+    t.integer  "imageable_id"
+    t.string   "imageable_type"
   end
-
-  add_index "images", ["member_id"], :name => "index_images_on_member_id"
 
   create_table "members", :force => true do |t|
     t.string   "uid"
@@ -75,8 +74,8 @@ ActiveRecord::Schema.define(:version => 20120504150757) do
     t.string   "bio"
     t.string   "github_username"
     t.string   "photo_url"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
     t.string   "access_token"
     t.string   "email"
   end
@@ -89,8 +88,8 @@ ActiveRecord::Schema.define(:version => 20120504150757) do
     t.string   "github_url"
     t.text     "description"
     t.string   "photo_url"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
     t.text     "html"
   end
 
@@ -101,8 +100,8 @@ ActiveRecord::Schema.define(:version => 20120504150757) do
     t.string   "response"
     t.integer  "guests"
     t.datetime "modified_at"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
   end
 
   add_index "rsvps", ["uid"], :name => "index_rsvps_on_uid"

--- a/spec/fixtures/http_responses/photos_for_event.json
+++ b/spec/fixtures/http_responses/photos_for_event.json
@@ -1,0 +1,37 @@
+{
+"results": [
+    {
+        "member": {
+            "name": "miles",
+            "member_id": 2836473
+        },
+        "photo_link": "http://photos2.meetupstatic.com/photos/event/5/7/8/2/600_55642402.jpeg",
+        "created": 1315926887000,
+        "updated": 1315926890000,
+        "highres_link": "http://photos2.meetupstatic.com/photos/event/5/7/8/2/highres_55642402.jpeg",
+        "thumb_link": "http://photos4.meetupstatic.com/photos/event/5/7/8/2/thumb_55642402.jpeg",
+        "photo_album": {
+            "group_id": 2270561,
+            "event_id": 28350831,
+            "photo_album_id": 3346582
+        },
+        "photo_id": 55642402
+    },
+    {
+        "member": {
+            "name": "miles",
+            "member_id": 2836473
+        },
+        "photo_link": "http://photos4.meetupstatic.com/photos/event/5/6/e/c/600_55642252.jpeg",
+        "created": 1315926825000,
+        "updated": 1315926827000,
+        "highres_link": "http://photos4.meetupstatic.com/photos/event/5/6/e/c/highres_55642252.jpeg",
+        "thumb_link": "http://photos4.meetupstatic.com/photos/event/5/6/e/c/thumb_55642252.jpeg",
+        "photo_album": {
+            "group_id": 2270561,
+            "event_id": 28350831,
+            "photo_album_id": 3346582
+        },
+        "photo_id": 55642252
+    }]
+}

--- a/spec/lib/tokyorails/meetup_tasks_spec.rb
+++ b/spec/lib/tokyorails/meetup_tasks_spec.rb
@@ -76,7 +76,9 @@ describe Tokyorails::MeetupTasks do
       WebMock.reset!
       WebMock.disable_net_connect!
       stub_request(:get, /.*events.json/).to_return(:body => get_response('events.json'))
+      stub_request(:get, /.*.jpeg/).to_return(:body => File.new(Rails.root.join('spec','fixtures','example.jpg')), :status => 200)
       stub_request(:get, /.*rsvps.json/).to_return(:body => get_response('rsvps_59784102.json'))
+      stub_request(:get, /.*photos.json/).to_return(:body => get_response('photos_for_event.json'))
       Tokyorails::MeetupTasks.import_events
       WebMock.reset!
     end
@@ -92,6 +94,10 @@ describe Tokyorails::MeetupTasks do
       Tokyorails::MeetupTasks.import_events
       event1.should == Event.first
       event2.should == Event.last
+    end
+    
+    it 'should also create images for each event' do
+      Image.count.should == 18
     end
   end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,6 +2,11 @@
 require 'spec_helper'
 
 describe Event do
+  
+  context "associations" do
+    it { should have_many(:images) }
+  end
+  
   context "given there are events" do
     let!(:next_event)     { Factory(:event, :status => 'upcoming', :time => Time.now) }
     let!(:previous_event) { Factory(:event, :status => 'past', :time => 1.month.ago) }
@@ -21,6 +26,17 @@ describe Event do
     describe '.recent' do
       it "returns the events ordered by date, most recent first" do
         Event.recent.should == [next_event, previous_event]
+      end
+    end
+    
+    describe 'each event' do
+      it "should be able to have images" do
+        stub_request(:get, "localhost/photo1.jpg").to_return(:body => File.new(Rails.root.join('spec','fixtures','example.jpg')), :status => 200)
+        stub_request(:get, "localhost/photo2.jpg").to_return(:body => File.new(Rails.root.join('spec','fixtures','example.jpg')), :status => 200)
+        
+        previous_event.images.create(:file_url => 'http://localhost/photo1.jpg')
+        previous_event.images.create(:file_url => 'http://localhost/photo2.jpg')
+        previous_event.images.size.should == 2
       end
     end
   end


### PR DESCRIPTION
- Please make sure to run db:migrate
- Photos for events are cleared and imported via the high-res link from the Meetup API /2/photos call every time import_events is run. Alternatively, we could separate this into a separate rake task that is run every day.

In addition, to extrapolate in this direction, we could perhaps have an intermediate-class (e.g. photo_url) that for checking against photos that currently exist in the system; of course. This class will only be used during the scheduled rake import/update tasks and never queried during actual application usage. 

This normalization allows us to keep the Image table as slim as possible and to cut out the otherwise useless Photo_URL column from the Members table for a bit of a speed gain.
