### PR TITLE
(Re)-Add an index to images

### DIFF
--- a/db/migrate/20120523004428_add_index_to_images.rb
+++ b/db/migrate/20120523004428_add_index_to_images.rb
@@ -1,0 +1,5 @@
+class AddIndexToImages < ActiveRecord::Migration
+  def change
+    add_index :images, [ :imageable_id, :imageable_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120517110348) do
+ActiveRecord::Schema.define(:version => 20120523004428) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(:version => 20120517110348) do
     t.string   "uid"
   end
 
+  add_index "images", ["imageable_id", "imageable_type"], :name => "index_images_on_imageable_id_and_imageable_type"
   add_index "images", ["uid"], :name => "index_images_on_uid"
 
   create_table "members", :force => true do |t|


### PR DESCRIPTION
When I added photos to events, I removed the index on member_id when I switched it to a polymorphic relationship, but I forgot to add an index on the polymorphic link (imageable_id and imageable_type).

Today, I noticed the site was slow when loading the events page, and hopefully this alleviates that issue (seemed to help on my local). Don't want visitors to think Rails is dog slow ;)
