### PR TITLE
Add events details page

### DIFF
--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -1,6 +1,6 @@
 @import 'mixins';
 
-body.events.index {
+body.events {
   li.events {
     @include active
   }
@@ -33,5 +33,10 @@ body.events.index {
       }
     }
   }
+}
 
+body.events.show {
+  .embed_html {
+    padding-top: 10px;
+  }
 }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,4 +4,8 @@ class EventsController < ApplicationController
     @past_events = Event.past
     @upcoming_events = Event.upcoming
   end
+
+  def show
+    @event = Event.find(params[:id])
+  end
 end

--- a/app/views/events/_event_photos.html.erb
+++ b/app/views/events/_event_photos.html.erb
@@ -1,0 +1,9 @@
+<% photo_options ||= '90x90#' %>
+
+<ul class="thumbnails">
+  <% event.images.each do |photo| %>
+    <li class="photo_photo">
+    <%= link_to image_tag(photo.thumb(photo_options).url, :alt => "", :'data-original-title' => "", :'data-content' => ""), photo.file.jpg.url, :class => "thumbnail", :target => "_blank" if photo %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -13,11 +13,7 @@
         <h2><%= link_to event.name, event.event_url %></h3>
         <p><%= l event.time, :format => :long %></p>
         <h3><%= t '.attending', :number => event.yes_rsvp_count %></h3>
-        <ul class="attending">
-          <% Rsvp.where(:meetup_id => event.uid).attending.each do |rsvp| %>
-            <li class="member"><%= image_tag(rsvp.member.photo.thumb('50x50#').url) if rsvp.member.present? %></li>
-          <% end %>
-        </ul>
+        <%= render :partial => "shared/event_attendee_photos", :locals => { :event => event, :photo_options => '50x50#'} %>
         <p>
           <%= link_to t('.join'), event.event_url, :class => "btn btn-success btn-large pull-right" %>
         </p>
@@ -31,22 +27,12 @@
 
   <% @past_events.recent.each do |event| %>
     <div class="row">
-      <h2><%= link_to event.name, event.event_url %></h3>
+      <h2><%= link_to event.name, event_path(event.id) %></h3>
       <h3><%= t '.attended', :number => event.yes_rsvp_count %></h3>
-      <ul class="attending">
-        <% Rsvp.where(:meetup_id => event.uid).attending.each do |rsvp| %>
-          <li class="member"><%= image_tag(rsvp.member.photo.thumb('30x30#').url) if rsvp.member.present? && rsvp.member.photo %></li>
-        <% end %>
-      </ul>
+      <%= render :partial => 'shared/event_attendee_photos', :locals => { :event => event, :photo_options => '30x30#'} %>
       <% unless event.images.empty? %>
         <h3><%= t '.photos' %></h3>
-        <ul class="thumbnails">
-          <% event.images.each do |photo| %>
-            <li class="photo_photo">
-            <%= link_to image_tag(photo.thumb('90x90#').url, :alt => "", :'data-original-title' => "", :'data-content' => ""), photo.file.jpg.url, :class => "thumbnail", :target => "_blank" if photo %>
-            </li>
-          <% end %>
-        </ul>
+        <%= render :partial => "event_photos", :locals => { :event => event, :photo_options => '50x50#' }%>
       <% end %>
 
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,35 @@
+<div class="hero-unit">
+
+  <div class="row">
+    <div class="span8">
+      <h1><%= @event.name %></h1>
+    </div>
+  </div>
+
+  <% unless @event.html.nil? %>
+    <div class="embed_html">
+      <%= @event.html.try(:html_safe) %>
+    </div>
+    <br/>
+  <% end %>
+
+  <% unless @event.yes_rsvp_count == 0%>
+    <h3><%= t '.attended', :number => @event.yes_rsvp_count %></h3>
+    <%= render :partial => 'shared/event_attendee_photos', :locals => { :event => @event, :photo_options => '30x30#'} %>
+    <br/>
+  <% end %>
+
+  <% unless @event.images.empty? %>
+    <h3><%= t '.photos' %></h3>
+    <%= render :partial => "event_photos", :locals => { :event => @event }%>
+    <br/>
+  <% end %>
+
+  <% unless @event.description.nil? %>
+    <h3><%= t '.summary' %></h3>
+    <%= @event.description.try(:html_safe) %>
+  <% end %>
+
+  </div>
+</div>
+

--- a/app/views/homepage/_next_event.html.erb
+++ b/app/views/homepage/_next_event.html.erb
@@ -7,11 +7,7 @@
   <div class="event-details">
     <div class="title"><%= link_to event.name, event.event_url %></div>
     <div class="subtitle"><%= l event.time, :format => :long %> &#9733; <%= event.yes_rsvp_count %> <%= t '.attending' %></div>
-    <ul class="attending">
-      <% Rsvp.where(:meetup_id => event.uid).attending.each do |rsvp| %>
-        <li class="member"><%= image_tag(rsvp.member.photo.thumb('30x30#').url) if rsvp.member.present? %></li>
-      <% end %>
-    </ul>
+    <%= render :partial => 'shared/event_attendee_photos', :locals => { :event => event, :photo_options => '30x30#'} %>
     <div class="rsvp"><%= link_to t('.register'), event.event_url, :class => "btn btn-success btn-large pull-right" %></div>
   </div>
 </div>

--- a/app/views/shared/_event_attendee_photos.html.erb
+++ b/app/views/shared/_event_attendee_photos.html.erb
@@ -1,0 +1,7 @@
+<% photo_options ||= '50x50#' %>
+
+<ul class="attending">
+  <% Rsvp.where(:meetup_id => event.uid).attending.each do |rsvp| %>
+    <li class="member"><%= image_tag(rsvp.member.photo.thumb(photo_options).url) if rsvp.member.present? && rsvp.member.photo %></li>
+  <% end %>
+</ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,10 @@ en:
       photos: Event Photos
       join: RSVP for the Next Meetup
       register: Register to Get Notified
+    show:
+      attended: "%{number} attended"
+      photos: Event Photos
+      summary: Summary
 
   members:
     index:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -32,6 +32,10 @@ ja:
       photos: イベントの写真
       join: 次のミートアップに参加申し込み
       register: 次のイベントに申込む
+    show:
+      attended: "%{number} 人が参加しました"
+      photos: イベントの写真
+      summary: 概要
 
   members:
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,6 @@ Tokyorails::Application.routes.draw do
 
   devise_for :admin_users, ActiveAdmin::Devise.config
 
-  match "/events/:id" => redirect("http://www.meetup.com/tokyo-rails/events/%{id}/")
-
   scope "(:locale)", :locale => /en|ja/ do
     resources :members
     resources :events

--- a/db/migrate/20120610053447_add_html_to_events.rb
+++ b/db/migrate/20120610053447_add_html_to_events.rb
@@ -1,0 +1,5 @@
+class AddHtmlToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :html, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120528133954) do
+ActiveRecord::Schema.define(:version => 20120610053447) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(:version => 20120528133954) do
     t.integer  "yes_rsvp_count"
     t.datetime "created_at",     :null => false
     t.datetime "updated_at",     :null => false
+    t.text     "html"
   end
 
   add_index "events", ["uid"], :name => "index_events_on_uid"

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -4,6 +4,8 @@ Factory.define :event do |f|
   f.status  'past'
   f.time 5.days.ago
   f.yes_rsvp_count 3
+  f.description '<p>Please RSVP for this event</p>'
+  f.html '<p>Additional HTML</p>'
 end
 
 Factory.sequence :uid do |n|

--- a/spec/requests/events_show_spec.rb
+++ b/spec/requests/events_show_spec.rb
@@ -1,0 +1,14 @@
+# -*- encoding : utf-8 -*-
+require 'spec_helper'
+
+feature "Show a event" do
+  scenario "Renders the details of an event" do
+    @event = Factory(:event, :status => 'past')
+    
+    visit event_path(:id => @event.id)
+    page.should have_content("#{@event.name}")
+    page.should have_content("Please RSVP for this event")
+    page.should have_content("Additional HTML")
+  end
+
+end


### PR DESCRIPTION
Related story here: https://trello.com/card/as-a-visitor-when-i-click-on-a-past-event-i-should-see-a-page-on-the-tokyorails-site-and-not-meetup-com-upcoming-should-still-go-to-meetup-com-for-now/4eb7e6bc90315800004faa0c/46

Clicking on a previous event now shows the details within TokyoRails. You also have the ability to add HTML to the event through ActiveAdmin (e.g. link to SpeakerDeck, Youtube, etc if you wish)

Added:
-Migration
-Show page for events (GET to events/:id)
-Tests
-Partials

Also modified a couple views to make things more DRY when rendering event photos and attendees
