### PR TITLE
Keep the members popup on the page.

### DIFF
--- a/app/assets/javascripts/members.js.coffee
+++ b/app/assets/javascripts/members.js.coffee
@@ -2,4 +2,5 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
 jQuery ->
-  $('.thumbnail').popover()
+  $('.thumbnail.popover-right').popover()
+  $('.thumbnail.popover-left').popover(placement: 'left')

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -3,7 +3,7 @@ module MembersHelper
   def join_interests(member)
     member.interests.map { |interest| interest }.join '  |  '
   end
-  
+
   def projects(member)
     if member.github_projects.empty?
       []
@@ -12,5 +12,12 @@ module MembersHelper
      projects = JSON.parse(data)
    end
   end
-  
+
+  def thumbnail_class(index)
+    if (index + 1) % 7 == 0
+      'thumbnail popover-left'
+    else
+      'thumbnail popover-right'
+    end
+  end
 end

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -8,10 +8,10 @@
   <% end %>
 
   <ul class="thumbnails">
-    <% @members.shuffle.each do |member| %>
+    <% @members.shuffle.each_with_index do |member, i| %>
       <% if member.photo %>
-        <li class="member_photo">
-          <%= link_to image_tag(member.photo.thumb('90x90#').url, :alt => member.name), member, :class => "thumbnail", :'title' => member.name, :'data-content' => member.bio %>
+        <li class="member_photo ">
+          <%= link_to image_tag(member.photo.thumb('90x90#').url, :alt => member.name), member, :class => thumbnail_class(i), :'title' => member.name, :'data-content' => member.bio %>
         </li>
       <% end %>
     <% end %>


### PR DESCRIPTION
On the members page, mousing over members on the right results in the popup going off the edge of the page. This change makes the popup show up on the left for the images on the right of the page.
