### PR TITLE
Make attendee photos link to the member

### DIFF
--- a/app/views/shared/_event_attendee_photos.html.erb
+++ b/app/views/shared/_event_attendee_photos.html.erb
@@ -2,6 +2,8 @@
 
 <ul class="attending">
   <% Rsvp.where(:meetup_id => event.uid).attending.each do |rsvp| %>
-    <li class="member"><%= image_tag(rsvp.member.photo.thumb(photo_options).url) if rsvp.member.present? && rsvp.member.photo %></li>
+    <li class="member">
+      <%= link_to(image_tag(rsvp.member.photo.thumb(photo_options).url), member_path(rsvp.member), :title => rsvp.member.name) if rsvp.member.present? && rsvp.member.photo %>
+    </li>
   <% end %>
 </ul>


### PR DESCRIPTION
Whilst using the site I wanted to be able to get more information about the members that attended the same meetup as me, but I found that I could only see the avatars and nothing else. So I quickly added links around the avatars which point to the respective member page and also include the member's name in the tooltip.

I didn't want to mess with the code or style, so it was the smallest change I could make that would add the require functionality. Hope it's OK!
